### PR TITLE
Update package name, tsconfig, license, homepage link, exported files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "files": [
     "contracts",
     "dist",
-    "build"
+    "build/artifacts"
   ],
   "scripts": {
     "build": "hardhat compile",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "license": "LGPL-3.0-only",
   "files": [
     "contracts",
-    "dist",
     "build/artifacts"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@safe-global/safe-token",
   "version": "1.0.0",
   "description": "Repository for Safe token related contracts",
-  "homepage": "https://www.safe.global",
+  "homepage": "https://safe.global",
   "license": "LGPL-3.0",
   "files": [
     "contracts",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
-  "name": "safe-token",
+  "name": "@safe-global/safe-token",
   "version": "1.0.0",
   "description": "Repository for Safe token related contracts",
-  "homepage": "https://www.gnosis-safe.io",
-  "license": "GPL-3.0",
+  "homepage": "https://www.safe.global",
+  "license": "LGPL-3.0",
   "files": [
     "contracts",
     "dist",
-    "src",
-    "test",
     "build"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Repository for Safe token related contracts",
   "homepage": "https://safe.global",
-  "license": "LGPL-3.0",
+  "license": "LGPL-3.0-only",
   "files": [
     "contracts",
     "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "node_modules"
   ],
   "include": [
-    "./src/index.ts",
-    "./types"
+    "./types",
+    "./src"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
     "node_modules"
   ],
   "include": [
-    "./types",
-    "./src"
+    "./src",
+    "./types"
   ]
 }


### PR DESCRIPTION
Fixes #31 

Changes in PR:
- Package name includes org name
- Update homepage link
- Use licence id `LGPL-3.0-only`
- Remove `test` and `src` from files
- Update tsconfig so that `/src` directory is included